### PR TITLE
Sanitize input to be able to consume prefixed and postfixed lines

### DIFF
--- a/packages/backend/src/index.mts
+++ b/packages/backend/src/index.mts
@@ -77,7 +77,12 @@ server.listen(config.port, () => {
 
 const parseLine = (line: string) => {
     try {
-        const value = JSON.parse(line);
+        const regex = /{.*}/g;
+        const jsonFound = line.match(regex);
+        if (!jsonFound || !jsonFound.length) {
+            throw new Error("Not object");
+        }
+        const value = JSON.parse(jsonFound[0]);
         if (typeof value !== "object" || value === null) {
             throw new Error("Not object");
         } else {

--- a/packages/backend/src/index.test.mjs
+++ b/packages/backend/src/index.test.mjs
@@ -80,4 +80,18 @@ describe("index", () => {
             ],
         });
     });
+
+    it("correctly sanitizes input", async () => {
+        cliProcess.stdin.write(
+            " some prefix | " +
+                JSON.stringify({ test: "test-1" }) +
+                " | some postfix " +
+                "\n",
+        );
+        const res = await got.get(`http://localhost:${PORT}/api/test/messages`);
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({
+            values: [{ test: "test-1" }],
+        });
+    });
 });


### PR DESCRIPTION
Sanitize input so that for example Localstack's prefixed input can be consumed. Also strip any potential postfix as well while at it.

# Example data
`[start-ls] localstack_main  | > {"level":10,"time":1677773201036,"pid":16,"hostname"` (input truncated)